### PR TITLE
Constrain script output display

### DIFF
--- a/DuctTape/DuctTapeApp.swift
+++ b/DuctTape/DuctTapeApp.swift
@@ -41,7 +41,6 @@ struct DuctTapeApp: App {
                             .font(.system(.body, design: .monospaced))
                             .lineLimit(1)
                             .truncationMode(.middle)
-                            .frame(maxWidth: outputSectionMaxWidth, alignment: .leading)
                         }
 
                         Section("PID") {
@@ -59,22 +58,17 @@ struct DuctTapeApp: App {
                                 Text("...")
                                     .font(.system(.body, design: .monospaced))
                             } else {
-                                ScrollView(.vertical, showsIndicators: true) {
-                                    VStack(alignment: .leading, spacing: 2) {
-                                        ForEach(script.outputLines, id: \.self) { line in
-                                            Text(line.count > maxOutputLineLength ? String(line.prefix(maxOutputLineLength)) + "..." : line)
-                                                .font(.system(.body, design: .monospaced))
-                                                .lineLimit(1)
-                                                .truncationMode(.tail)
-                                                .frame(maxWidth: outputSectionMaxWidth, alignment: .leading)
-                                        }
-                                    }
-                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                let displayLines = script.outputLines.suffix(maxOutputLines)
+                                let truncatedLines = displayLines.map { line in
+                                    line.count > maxOutputLineLength ? String(line.prefix(maxOutputLineLength)) + "..." : line
                                 }
-                                .frame(maxWidth: outputSectionMaxWidth, maxHeight: outputSectionMaxHeight)
+                                Text(truncatedLines.joined(separator: "\n"))
+                                    .font(.system(.body, design: .monospaced))
+                                    .fixedSize(horizontal: false, vertical: true)
                             }
                         }
                     }
+                    .frame(maxWidth: maxMenuWidth, alignment: .leading)
                 }
 
                 Divider()

--- a/DuctTape/DuctTapeApp.swift
+++ b/DuctTape/DuctTapeApp.swift
@@ -39,6 +39,9 @@ struct DuctTapeApp: App {
                                 NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: script.url.deletingLastPathComponent().path)
                             }
                             .font(.system(.body, design: .monospaced))
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                            .frame(maxWidth: outputSectionMaxWidth, alignment: .leading)
                         }
 
                         Section("PID") {
@@ -56,10 +59,19 @@ struct DuctTapeApp: App {
                                 Text("...")
                                     .font(.system(.body, design: .monospaced))
                             } else {
-                                ForEach(script.outputLines, id: \.self) { line in
-                                    Text(line)
-                                        .font(.system(.body, design: .monospaced))
+                                ScrollView(.vertical, showsIndicators: true) {
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        ForEach(script.outputLines, id: \.self) { line in
+                                            Text(line.count > maxOutputLineLength ? String(line.prefix(maxOutputLineLength)) + "..." : line)
+                                                .font(.system(.body, design: .monospaced))
+                                                .lineLimit(1)
+                                                .truncationMode(.tail)
+                                                .frame(maxWidth: outputSectionMaxWidth, alignment: .leading)
+                                        }
+                                    }
+                                    .frame(maxWidth: .infinity, alignment: .leading)
                                 }
+                                .frame(maxWidth: outputSectionMaxWidth, maxHeight: outputSectionMaxHeight)
                             }
                         }
                     }

--- a/DuctTape/ScriptModel.swift
+++ b/DuctTape/ScriptModel.swift
@@ -3,8 +3,7 @@ import Foundation
 // Config
 let maxOutputLines = 20
 let maxOutputLineLength = 80
-let outputSectionMaxWidth: CGFloat = 350
-let outputSectionMaxHeight: CGFloat = 150
+let maxMenuWidth: CGFloat = 350
 
 enum ScriptStatus {
     case idle

--- a/DuctTape/ScriptModel.swift
+++ b/DuctTape/ScriptModel.swift
@@ -2,6 +2,9 @@ import Foundation
 
 // Config
 let maxOutputLines = 20
+let maxOutputLineLength = 80
+let outputSectionMaxWidth: CGFloat = 350
+let outputSectionMaxHeight: CGFloat = 150
 
 enum ScriptStatus {
     case idle


### PR DESCRIPTION
Constrain script output and path display width and add vertical scrolling to prevent the menu bar from expanding excessively.